### PR TITLE
Devops/et 772 releases fix

### DIFF
--- a/.github/workflows/build-multi-arch.yml
+++ b/.github/workflows/build-multi-arch.yml
@@ -140,7 +140,7 @@ jobs:
           version: ${{ inputs.version }}
           amd_tag: ${{ inputs.build_id }}_amd-64
           arm_tag: ${{ inputs.build_id }}_arm-64
-          updated_tags: ${{ inputs.updated_tags}}
+          updated_tags: ${{ inputs.updated_tags }}
           module: ${{ needs.lowercase-module.outputs.module_lowercase }}
           release_modules: ${{ inputs.release_modules }}
           acr: ${{ inputs.acr }}

--- a/.github/workflows/build-multi-arch.yml
+++ b/.github/workflows/build-multi-arch.yml
@@ -135,7 +135,7 @@ jobs:
         run: |
           echo "${{ inputs.updated_tags }}"
       - name: build-multi-arch
-        uses: IQGeo/devops-engineering-ci-public-multi-arch-action@devops/ET-772-releases-fix
+        uses: IQGeo/devops-engineering-ci-public-multi-arch-action@main
         with:
           version: ${{ inputs.version }}
           amd_tag: ${{ inputs.build_id }}_amd-64

--- a/.github/workflows/build-multi-arch.yml
+++ b/.github/workflows/build-multi-arch.yml
@@ -24,8 +24,9 @@ on:
           description: 'Module to build (product, devdb, editions)'
           type: string
           required: true
-        main_module:
-          description: 'Whether this module is the main module (product) or a supporting module (devdb, editions)'
+        release_modules:
+          description: 'Comma-separated list of modules to include in release repostitories'
+          required: true
           type: string
         updated_tags:
           description: 'Comma-seperated list of new tags to retag multi arch image as once it is built (pre-release, latest)'
@@ -141,7 +142,7 @@ jobs:
           arm_tag: ${{ inputs.build_id }}_arm-64
           updated_tags: ${{ inputs.updated_tags}}
           module: ${{ needs.lowercase-module.outputs.module_lowercase }}
-          main_module: ${{ inputs.main_module }}
+          release_modules: ${{ inputs.release_modules }}
           acr: ${{ inputs.acr }}
           harbor: ${{ inputs.harbor }}
           registry_username : ${{ secrets.REGISTRY_USERNAME  }}

--- a/.github/workflows/build-multi-arch.yml
+++ b/.github/workflows/build-multi-arch.yml
@@ -24,6 +24,9 @@ on:
           description: 'Module to build (product, devdb, editions)'
           type: string
           required: true
+        main_module:
+          description: 'Whether this module is the main module (product) or a supporting module (devdb, editions)'
+          type: string
         updated_tags:
           description: 'Comma-seperated list of new tags to retag multi arch image as once it is built (pre-release, latest)'
           type: string
@@ -131,13 +134,14 @@ jobs:
         run: |
           echo "${{ inputs.updated_tags }}"
       - name: build-multi-arch
-        uses: IQGeo/devops-engineering-ci-public-multi-arch-action@main
+        uses: IQGeo/devops-engineering-ci-public-multi-arch-action@devops/ET-772-releases-fix
         with:
           version: ${{ inputs.version }}
           amd_tag: ${{ inputs.build_id }}_amd-64
           arm_tag: ${{ inputs.build_id }}_arm-64
           updated_tags: ${{ inputs.updated_tags}}
           module: ${{ needs.lowercase-module.outputs.module_lowercase }}
+          main_module: ${{ inputs.main_module }}
           acr: ${{ inputs.acr }}
           harbor: ${{ inputs.harbor }}
           registry_username : ${{ secrets.REGISTRY_USERNAME  }}


### PR DESCRIPTION
Added release_modules input and left as required since the previous build-module-workflow always has a default value of at least 'none' so there will always be an input passed here, either the default value or the overwritten value passed in from the main module workflow. Then release_modules is passed downstream to the build-push-action.

Also fixed some spacing on updated_tags var. 

Successful test run using a .final tag where workflow_manager was pushed to releases (that's the only one I set in the main build-workflow-manager workflow) but all other injectors and platform-with-workflow-manager were not pushed to releases_ in ACR and Harbor: https://github.com/IQGeo/myworld-product-workflow-manager/actions/runs/19947382314
(I used the devops_sandbox_engineering and devops_sandbox_releases image repositories so that nothing during development was pushed to actual releases folders.)