### PR TITLE
ET-772: release_modules: input with default should not be required

### DIFF
--- a/.github/workflows/build-multi-arch.yml
+++ b/.github/workflows/build-multi-arch.yml
@@ -26,8 +26,9 @@ on:
           required: true
         release_modules:
           description: 'Comma-separated list of modules to include in release repostitories'
-          required: true
+          required: false       
           type: string
+          default: ''  # An empty string means no modules are included in release repositories
         updated_tags:
           description: 'Comma-seperated list of new tags to retag multi arch image as once it is built (pre-release, latest)'
           type: string


### PR DESCRIPTION
When an input has a default, it should not be required.

In this case, we had the correct behavior in build-modules-workflow, but build-multi-arch-workflow and build-multi-arch-action both had required: true.

The Platform and SaaS workflows don't make use of build-modules-workflow

While making the required adjustment, I also found I would prefer if defaults are representative of their expected data; in this case an empty comma separated list.

I added some mock tests for the condition logic: https://github.com/IQGeo/editions-telecom/actions/workflows/dummy-workflow.yml

